### PR TITLE
Bump lxml to 4.6.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==7.1.2
 feedgen==0.9.0
 idna==2.9
 Jinja2==2.11.3
-lxml==4.6.3
+lxml==4.6.5
 markdown-table==2019.4.13
 MarkupSafe==1.1.1
 oauthlib==3.1.0


### PR DESCRIPTION
Response to https://github.com/advisories/GHSA-55x5-fj6c-h6m8

Don't *think* it's a security issue here, but good to take care of it anyways.